### PR TITLE
Alternative way of retrieving dependencies without repository

### DIFF
--- a/dsl/procedures/RetrieveDependencies/procedure.dsl
+++ b/dsl/procedures/RetrieveDependencies/procedure.dsl
@@ -1,11 +1,11 @@
 import java.io.File
 
-def procName = 'RetrieveDependencies'
+def procName = 'Setup'
 procedure procName, description: 'Retrieves Groovy dependencies. This procedure can be used as a first step of the procedure which requires dependencies.', {
     property 'standardStepPicker', value: false
 
 	step 'Setup',
-        command: new File(pluginDir, "dsl/procedures/$procName/steps/retrieveDependencies.pl").text,
+        command: new File(pluginDir, "dsl/procedures/RetrieveDependencies/steps/retrieveDependencies.pl").text,
         shell: 'ec-perl'
 }
 


### PR DESCRIPTION
This is POC for the new retrieving procedure. In order for this to work correctly, we should know a name of server-assigned resource (when it is something else then "local"). I guess we can store it in server properties.